### PR TITLE
(Fix) Modify dotfiles to compile in Travis' environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ archlinux:
   script:
     - HOME=~/dotfiles-target ./install --only yay
     - HOME=~/dotfiles-target ./install --except yay
+    - HOME=~/dotfiles-target ./install -c opt.conf.yaml
+    - HOME=~/dotfiles-target ./install -c spotify.conf.yaml
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,11 @@ archlinux:
     - git
   before_install:
     - sudo pacman -Syy
-    - mkdir -p ~/dotfiles-target
   script:
-    - HOME=~/dotfiles-target ./install --only yay
-    - HOME=~/dotfiles-target ./install --except yay
-    - HOME=~/dotfiles-target ./install -c opt.conf.yaml
-    - HOME=~/dotfiles-target ./install -c spotify.conf.yaml
+    - ./install --only yay
+    - ./install --except yay
+    - ./install -c opt.conf.yaml
+    - ./install -c spotify.conf.yaml
 
 language: python
 python:

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -3,6 +3,8 @@
       create: true
       relink: true
       force: true
+    shell:
+      stdout: true
 
 - clean:
     ~/:
@@ -37,126 +39,33 @@
     ~/.vimrc:
     ~/.vim:
     ~/.pam_environment:
-    ~/.wallpaper:                             .media/wallpaper/Desktop/
-    ~/.config/i3/config:                      config/i3/config
+    ~/.wallpaper: .media/wallpaper/Desktop/
+    ~/.config/i3/config: config/i3/config
     ~/.config/polybar:
       glob: true
       path: config/polybar/*
-    ~/.config/ranger:
-      glob: true
-      path: config/ranger/*
     ~/.config/rofi:
       glob: true
       path: config/rofi/*
-    ~/.config/keepassxc/keepassxc.ini:        config/keepassxc/keepassxc.ini
-    ~/.config/gtk-3.0/settings.ini:           config/gtk-3.0/settings.ini
-    ~/.config/deadd/deadd.conf:               config/deadd/deadd.conf
-    ~/.config/picom.conf:                     config/picom.conf
-    ~/.config/flameshot:
-      glob: true
-      path: config/flameshot/*
-    ~/.config/systemd/user/ssh-agent.service: config/systemd/user/ssh-agent.service
-    ~/.config/spicetify/Themes/Dribbblish:    config/spicetify/Themes/spicetify-themes/Dribbblish
-    ~/.icons/default/index.theme:             icons/default/index.theme
-    ~/.gnupg/gpg.conf:                        gnupg/gpg.conf
+    ~/.config/gtk-3.0/settings.ini: config/gtk-3.0/settings.ini
+    ~/.config/deadd/deadd.conf: config/deadd/deadd.conf
+    ~/.config/picom.conf: config/picom.conf
+    ~/.icons/default/index.theme: icons/default/index.theme
+    ~/.gnupg/gpg.conf: gnupg/gpg.conf
 
 - shell:
     -
       command: yay --noconfirm
       description: Performing system upgrade using yay
       stdin: true
-      stdout: true
-
-- yay:
-    # Essentials
-    - vim                           # ;)
-    - man-db                        # for some reason arch doesn't install this by default..?
-    - openssh                       # no installation is complete without ssh...
-    - udevil                        # mostly for devmon
-    # Terminal/ZSH
-    - zsh
-    - oh-my-zsh-git
-    - zsh-completions
-    - tldr                          # I've always wanted this to exist.. but never actually checked if it does
-    - trash-cli
-    # Interface
-    - xorg-server
-    - xorg-apps
-    - xorg-xinit
-    - xorg-xrdb
-    - picom                         # composition manager (for transparency, blur, etc)
-    - libnotify                     # notifications
-    - deadd-notification-center-bin # notification daemon
-    - i3-gaps
-    - rxvt-unicode
-    - ranger
-    - mpv                           # minimalistic, but fully featured video player
-    - w3m                           # powerful utility, I'm using it mainly for image preview in ranger
-    - rofi
-    - polybar
-    - flameshot                     # screen capture utility, bindings in i3
-    - unclutter-xfixes-git          # mouse hiding daemon - hides mouse when it is still for a while
-    # Fonts
-    - ttf-dejavu                    # default font for urxvt & some gui apps
-    - ttf-unifont                   # unicode characters (especially chinese & cyrilic)
-    - terminus-font                 # non-gui terminal font (vconsole.conf)
-    - ttf-roboto                    # general purpose font (popular on web)
-    - ttf-fantasque-sans-mono       # polybar
-    - ttf-material-icons-git        # polybar
-    # Audio
-    - pulseaudio
-    - pulseaudio-alsa
-    - pulseaudio-modules-bt
-    - pavucontrol-qt
-    # Tools/Apps
-    - rsync
-    - playerctl
-    - feh
-    - dex
-    - chromium
-    - keepassxc
-    - syncthing
-    - syncthingtray
-    - discord
-    - telegram-desktop
-    - ttf-opensans                  # telegram-desktop dependency
-    - spotify
-    - spotify-tray-git
-    - spicetify-cli
-    # Filesystem support
-    - exfat-utils-nofuse
-    - cifs-utils
-    - smbclient
-    # Dotbot-sudo dependency
-    - python-yaml
-
-- sudo:
-    - shell:
-      - sudo chmod a+wr /opt/spotify
-      - sudo chmod a+wr /opt/spotify/Apps -R
-
-- shell:    
-  # Enable ssh-agent
-  - systemctl --user enable ssh-agent
-  - systemctl --user enable syncthing
- 
-  # Spiceify
-  - spicetify 
-  - spicetify backup enable-devtool
-  - cp "$(dirname "$(spicetify -c)")/Themes/Dribbblish/dribbblish.js" "$(dirname "$(spicetify -c)")/Extensions"
-  - spicetify config extensions dribbblish.js 
-  - spicetify config current_theme Dribbblish color_scheme dracula
-  - spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
-  - spicetify apply
 
 - sudo:
     - link:
         /etc/vconsole.conf:
           path: system/etc/vconsole.conf
           force: true
-        /etc/X11/xorg.conf.d/00-keyboard.conf:  system/etc/X11/xorg.conf.d/00-keyboard.conf
-        /usr/share/themes/Midnight-GrayNight:   system/usr/share/themes/Midnight-GrayNight
-        /etc/udevil/udevil.conf:                system/etc/udevil/udevil.conf
+        /etc/X11/xorg.conf.d/00-keyboard.conf: system/etc/X11/xorg.conf.d/00-keyboard.conf
+        /usr/share/themes/Midnight-GrayNight: system/usr/share/themes/Midnight-GrayNight
         /etc/resolv.conf:
           path: system/etc/resolv.conf
           relink: true
@@ -164,3 +73,30 @@
     - shell:
       - systemctl enable systemd-networkd
       - systemctl enable systemd-resolved
+
+- yay:
+    - zsh
+    - oh-my-zsh-git
+ 
+    - xorg-server
+    - xorg-apps
+    - xorg-xinit
+    - xorg-xrdb
+    - i3-gaps
+    - rxvt-unicode
+    - rofi
+    - polybar
+
+    - ttf-dejavu                    # default font for urxvt & some gui apps
+    - ttf-unifont                   # unicode characters (especially chinese & cyrilic)
+    - terminus-font                 # non-gui terminal font (vconsole.conf)
+    - ttf-roboto                    # general purpose font (popular on web)
+    - ttf-fantasque-sans-mono       # polybar
+    - ttf-material-icons-git        # polybar
+
+    - picom                         # composition manager (for transparency, blur, etc)
+    - dex                           # desktop entry launcher (also generator)
+    - libnotify                     # notifications
+    - deadd-notification-center-bin # notification daemon
+
+    - python-yaml

--- a/opt.conf.yaml
+++ b/opt.conf.yaml
@@ -1,0 +1,61 @@
+- defaults:
+    link:
+      create: true
+      relink: true
+      force: true
+    shell:
+      stdout: true
+
+- link:
+    ~/.config/ranger:
+      glob: true
+      path: config/ranger/*
+    ~/.config/keepassxc/keepassxc.ini:        config/keepassxc/keepassxc.ini
+    ~/.config/flameshot:
+      glob: true
+      path: config/flameshot/*
+    ~/.config/systemd/user/ssh-agent.service: config/systemd/user/ssh-agent.service
+
+- yay:
+    - gvim                  # ;)
+    - man-db                # for some reason arch doesn't install this by default..?
+    - openssh               # no installation is complete without ssh...
+    - udevil                # mostly for devmon
+
+    - zsh-completions
+    - tldr                  # I've always wanted this to exist.. but never actually checked if it does
+    - trash-cli
+
+    - ranger
+    - mpv                   # minimalistic, but fully featured video player
+    - w3m                   # powerful utility, I'm using it mainly for image preview in ranger
+    - flameshot             # screen capture utility, bindings in i3
+    - unclutter-xfixes-git  # mouse hiding daemon - hides mouse when it is still for a while
+    
+    - pulseaudio
+    - pulseaudio-alsa
+    - pulseaudio-modules-bt
+    - pavucontrol-qt
+
+    - rsync
+    - playerctl
+    - feh
+    - chromium
+    - keepassxc
+    - syncthing
+    - syncthingtray
+    - discord
+    - telegram-desktop
+    - ttf-opensans          # telegram-desktop dependency
+
+    - exfat-utils-nofuse
+    - cifs-utils
+    - smbclient
+
+- shell:
+    - systemctl --user enable ssh-agent
+    - systemctl --user enable syncthing
+
+- sudo:
+    - link:
+        /etc/udevil/udevil.conf:  system/etc/udevil/udevil.conf

--- a/spotify.conf.yaml
+++ b/spotify.conf.yaml
@@ -1,0 +1,25 @@
+- link:
+    ~/.config/spicetify/Themes/Dribbblish: 
+      path: config/spicetify/Themes/spicetify-themes/Dribbblish
+      create: true
+      relink: true
+      force:  true
+
+- yay:
+    - spotify
+    - spotify-tray-git
+    - spicetify-cli
+
+- sudo:
+    - shell:
+      - sudo chmod a+wr /opt/spotify
+      - sudo chmod a+wr /opt/spotify/Apps -R
+
+- shell:
+  - spicetify
+  - spicetify backup enable-devtool
+  - cp "$(dirname "$(spicetify -c)")/Themes/Dribbblish/dribbblish.js" "$(dirname "$(spicetify -c)")/Extensions"
+  - spicetify config extensions dribbblish.js
+  - spicetify config current_theme Dribbblish color_scheme dracula
+  - spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
+  - spicetify apply

--- a/spotify.conf.yaml
+++ b/spotify.conf.yaml
@@ -24,7 +24,7 @@
       - sudo chmod a+wr /opt/spotify/Apps -R
 
 - create:
-    ~/.config/spotify
+    - ~/.config/spotify
 
 - shell:
   - touch ~/.config/spotify/prefs

--- a/spotify.conf.yaml
+++ b/spotify.conf.yaml
@@ -23,7 +23,11 @@
       - sudo chmod a+wr /opt/spotify
       - sudo chmod a+wr /opt/spotify/Apps -R
 
+- create:
+    ~/.config/spotify
+
 - shell:
+  - touch ~/.config/spotify/prefs
   - spicetify -n
   - spicetify -n backup enable-devtool
   - cp "$(dirname "$(spicetify -c)")/Themes/Dribbblish/dribbblish.js" "$(dirname "$(spicetify -c)")/Extensions"

--- a/spotify.conf.yaml
+++ b/spotify.conf.yaml
@@ -1,3 +1,11 @@
+- defaults:
+    link:
+      create: true
+      relink: true
+      force: true
+    shell:
+      stdout: true
+
 - link:
     ~/.config/spicetify/Themes/Dribbblish: 
       path: config/spicetify/Themes/spicetify-themes/Dribbblish
@@ -16,10 +24,10 @@
       - sudo chmod a+wr /opt/spotify/Apps -R
 
 - shell:
-  - spicetify
-  - spicetify backup enable-devtool
+  - spicetify -n
+  - spicetify -n backup enable-devtool
   - cp "$(dirname "$(spicetify -c)")/Themes/Dribbblish/dribbblish.js" "$(dirname "$(spicetify -c)")/Extensions"
   - spicetify config extensions dribbblish.js
   - spicetify config current_theme Dribbblish color_scheme dracula
   - spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
-  - spicetify apply
+  - spicetify -n apply


### PR DESCRIPTION
The issue was mostly running `spiceify` without first running spotify - as one would in a normal system (because on wouldn't use -n arguments). I've also removed the separate home directory - as we are running in an Arch environment now, this isn't really needed.